### PR TITLE
Update mdrnn to tf2 api and eliminated session and compute graph

### DIFF
--- a/impsy/interaction.py
+++ b/impsy/interaction.py
@@ -29,31 +29,22 @@ def setup_logging(dimension, location="logs/"):
     click.secho(f"Logging enabled: {log_file}", fg="green")
 
 
-def build_network(sess, compute_graph, config):
+def build_network(config):
     """Build the MDRNN, uses a high-level size parameter and dimension."""
     import impsy.mdrnn as mdrnn
-    import tensorflow.compat.v1 as tf
 
-    dimension = config["model"]["dimension"]
-    size = config["model"]["size"]
-    click.secho(f"MDRNN: Using {size} model.", fg="green")
-    model_config = mdrnn_config(size)
-    mdrnn_units = model_config["units"]
-    mdrnn_layers = model_config["layers"]
-    mdrnn_mixes = model_config["mixes"]
-    # construct the model
+    click.secho(f"MDRNN: Using {config['model']['size']} model.", fg="green")
+    model_config = mdrnn_config(config["model"]["size"])
     mdrnn.MODEL_DIR = "./models/"
-    tf.keras.backend.set_session(sess)
-    with compute_graph.as_default():
-        net = mdrnn.PredictiveMusicMDRNN(
-            mode=mdrnn.NET_MODE_RUN,
-            dimension=dimension,
-            n_hidden_units=mdrnn_units,
-            n_mixtures=mdrnn_mixes,
-            layers=mdrnn_layers,
-        )
-        net.pi_temp = config["model"]["pitemp"]
-        net.sigma_temp = config["model"]["sigmatemp"]
+    net = mdrnn.PredictiveMusicMDRNN(
+        mode=mdrnn.NET_MODE_RUN,
+        dimension=config["model"]["dimension"],
+        n_hidden_units=model_config["units"],
+        n_mixtures=model_config["mixes"],
+        layers=model_config["layers"],
+    )
+    net.pi_temp = config["model"]["pitemp"]
+    net.sigma_temp = config["model"]["sigmatemp"]
     click.secho(f"MDRNN Loaded: {net.model_name()}", fg="green")
     return net
 
@@ -88,14 +79,13 @@ class InteractionServer(object):
         self.senders.append(self.websocket_sender)
 
         # Import Keras and tensorflow
-        ## TODO may be better to do this only when needed.
         click.secho("Importing MDRNN.", fg="yellow")
         start_import = time.time()
         import impsy.mdrnn as mdrnn
-        import tensorflow.compat.v1 as tf
 
         click.secho(
-            f"Done. That took {time.time() - start_import} seconds.", fg="yellow"
+            f"Done. That took {round(time.time() - start_import, 2)} seconds.",
+            fg="yellow",
         )
 
         # Interaction Loop Parameters
@@ -201,16 +191,12 @@ class InteractionServer(object):
             )
             self.send_back_values(output_values)
 
-    def make_prediction(self, sess, compute_graph, neural_net):
+    def make_prediction(self, neural_net):
         """Part of the interaction loop: reads input, makes predictions, outputs results"""
-        import tensorflow.compat.v1 as tf
-
         # First deal with user --> MDRNN prediction
         if self.user_to_rnn and not self.interface_input_queue.empty():
             item = self.interface_input_queue.get(block=True, timeout=None)
-            tf.keras.backend.set_session(sess)
-            with compute_graph.as_default():
-                rnn_output = neural_net.generate_touch(item)
+            rnn_output = neural_net.generate_touch(item)
             if self.rnn_to_sound:
                 self.rnn_output_buffer.put_nowait(rnn_output)
             self.interface_input_queue.task_done()
@@ -222,9 +208,7 @@ class InteractionServer(object):
             and not self.rnn_prediction_queue.empty()
         ):
             item = self.rnn_prediction_queue.get(block=True, timeout=None)
-            tf.keras.backend.set_session(sess)
-            with compute_graph.as_default():
-                rnn_output = neural_net.generate_touch(item)
+            rnn_output = neural_net.generate_touch(item)
             self.rnn_output_buffer.put_nowait(
                 rnn_output
             )  # put it in the playback queue.
@@ -298,28 +282,15 @@ class InteractionServer(object):
 
     def serve_forever(self):
         """Run the interaction server opening required IO."""
-        # Import Keras and tensorflow, doing this later to make CLI more responsive.
-        import impsy.mdrnn as mdrnn
-        import tensorflow.compat.v1 as tf
-
-        click.secho("Importing MDRNN.", fg="yellow")
-
-        # Build model
-        compute_graph = tf.Graph()
-        with compute_graph.as_default():
-            sess = tf.Session()
-        net = build_network(sess, compute_graph, self.config)
-
-        # Load model weights
+        click.secho("Building MDRNN.", fg="yellow")
+        net = build_network(self.config)
         click.secho("Preparing MDRNN.", fg="yellow")
-        tf.keras.backend.set_session(sess)
-        with compute_graph.as_default():
-            if self.config["model"]["file"] != "":
-                net.load_model(
-                    model_file=self.config["model"]["file"]
-                )  # load custom model.
-            else:
-                net.load_model()  # try loading from default file location.
+        if self.config["model"]["file"] != "":
+            net.load_model(
+                model_file=self.config["model"]["file"]
+            )  # load custom model.
+        else:
+            net.load_model()  # try loading from default file location.
 
         # Threads
         click.secho("Preparing MDRNN thread.", fg="yellow")
@@ -337,7 +308,7 @@ class InteractionServer(object):
             rnn_thread.start()
             click.secho("RNN Thread Started", fg="green")
             while True:
-                self.make_prediction(sess, compute_graph, net)
+                self.make_prediction(net)
                 if self.config["interaction"]["mode"] == "callresponse":
                     for sender in self.senders:
                         sender.handle()  # handle incoming inputs

--- a/impsy/interaction.py
+++ b/impsy/interaction.py
@@ -84,7 +84,7 @@ class InteractionServer(object):
         import impsy.mdrnn as mdrnn
 
         click.secho(
-            f"Done. That took {round(time.time() - start_import, 2)} seconds.",
+            f"Done in {round(time.time() - start_import, 2)}s.",
             fg="yellow",
         )
 

--- a/impsy/mdrnn/__init__.py
+++ b/impsy/mdrnn/__init__.py
@@ -72,36 +72,52 @@ def build_model(
     """
     print("Building EMPI Model...")
     if inference:
-        stateful = True
-        batch_size = 1
+        state_input_output = True
     else:
-        stateful = False
-        batch_size = None
-    inputs = tf.keras.layers.Input(
-        shape=(seq_len, out_dim), name="inputs", batch_size=batch_size
+        state_input_output = False
+    data_input = tf.keras.layers.Input(
+        shape=(seq_len, out_dim), name="inputs"
     )
-    # batch_shape=batch_shape)
-    lstm_in = inputs  # starter input for lstm
+    lstm_in = data_input  # starter input for lstm
+    state_inputs = [] # storage for LSTM state inputs
+    state_outputs = [] # storage for LSTM state outputs
+
     for layer_i in range(layers):
-        ret_seq = True
+        return_sequences = True
         if (layer_i == layers - 1) and not time_dist:
             # return sequences false if last layer, and not time distributed.
-            ret_seq = False
-        lstm_out = tf.keras.layers.LSTM(
+            return_sequences = False
+        state_input = None
+        if state_input_output:
+            state_h_input = tf.keras.layers.Input(shape=(hidden_units,), name=f"state_h_{layer_i}")
+            state_c_input = tf.keras.layers.Input(shape=(hidden_units,), name=f"state_c_{layer_i}")
+            state_input = [state_h_input, state_c_input]
+            state_inputs += state_input
+        lstm_out, state_h_output, state_c_output = tf.keras.layers.LSTM(
             hidden_units,
-            name="lstm" + str(layer_i),
-            return_sequences=ret_seq,
-            stateful=stateful,
-        )(lstm_in)
+            name=f"lstm_{layer_i}",
+            return_sequences=return_sequences,
+            return_state= True # state_input_output # better to keep these outputs and just not use.
+        )(lstm_in, initial_state=state_input)
         lstm_in = lstm_out
+        state_outputs += [state_h_output, state_c_output]
 
     mdn_layer = mdn.MDN(out_dim, num_mixtures, name="mdn_outputs")
     if time_dist:
         mdn_layer = tf.keras.layers.TimeDistributed(mdn_layer, name="td_mdn")
     mdn_out = mdn_layer(lstm_out)  # apply mdn
-    model = tf.keras.models.Model(inputs=inputs, outputs=mdn_out)
+    if inference:
+        # for inference, need to track state of the model
+        inputs = [data_input] + state_inputs
+        outputs = [mdn_out] + state_outputs
+    else:
+        # for training we don't need to keep track of state in the model
+        inputs = data_input
+        outputs = mdn_out
+    model = tf.keras.models.Model(inputs=inputs, outputs=outputs)
 
     if not inference:
+        # only need loss function and compile when training
         loss_func = mdn.get_mixture_loss_func(out_dim, num_mixtures)
         optimizer = tf.keras.optimizers.Adam()
         model.compile(loss=loss_func, optimizer=optimizer)
@@ -144,62 +160,9 @@ def proc_generated_touch(x_input, out_dim=2):
     such that dt > 0, and 0 <= x <= 1"""
     dt = np.maximum(
         x_input[0], 0.000454
-    )  # TODO: see if the min value of dt shoud change.
+    )  # TODO: see if the min value of dt should change.
     x_output = np.minimum(np.maximum(x_input[1:], 0), 1)
     return np.concatenate([np.array([dt]), x_output])
-
-
-def generate_sample(
-    model, n_mixtures, prev_sample, pi_temp=1.0, sigma_temp=0.0, out_dim=2
-):
-    """Generate one forward prediction from a previous sample in format
-    (dt, x_1,...,x_n). Pi and Sigma temperature are adjustable."""
-    model_output = model(prev_sample.reshape(1, 1, out_dim) * SCALE_FACTOR)
-    mdn_params = model_output[0].numpy()
-    new_sample = (
-        mdn.sample_from_output(
-            mdn_params, out_dim, n_mixtures, temp=pi_temp, sigma_temp=sigma_temp
-        )
-        / SCALE_FACTOR
-    )
-    new_sample = new_sample.reshape(
-        out_dim,
-    )
-    return new_sample
-
-
-def generate_performance(
-    model,
-    n_mixtures,
-    first_sample,
-    time_limit=None,
-    steps_limit=1000,
-    pi_temp=1.0,
-    sigma_temp=0.0,
-    out_dim=2,
-):
-    """Generates a performance of (dt, x) pairs, up to a step_limit.
-    Time limit is not presently implemented.
-    """
-    time = 0
-    steps = 0
-    prev_sample = first_sample
-    print(prev_sample)
-    performance = [prev_sample.reshape((out_dim,))]
-    while steps < steps_limit:  # and time < time_limit
-        params = model.predict(prev_sample.reshape(1, 1, out_dim) * SCALE_FACTOR)
-        prev_sample = mdn.sample_from_output(
-            params[0], out_dim, n_mixtures, temp=pi_temp, sigma_temp=sigma_temp
-        )
-        prev_sample = prev_sample / SCALE_FACTOR
-        output_touch = prev_sample.reshape(
-            out_dim,
-        )
-        output_touch = proc_generated_touch(output_touch)
-        performance.append(output_touch.reshape((out_dim,)))
-        steps += 1
-        time += output_touch[0]
-    return np.array(performance)
 
 
 class PredictiveMusicMDRNN(object):
@@ -257,6 +220,15 @@ class PredictiveMusicMDRNN(object):
             )
 
         self.run_name = self.get_run_name()
+        self.reset_lstm_states()
+
+
+    def reset_lstm_states(self):
+        states = []
+        for i in range(self.n_rnn_layers):
+            states += [np.zeros((1,self.n_hidden_units), dtype=np.float32), np.zeros((1,self.n_hidden_units), dtype=np.float32)]
+        assert len(states) == self.n_rnn_layers * 2, "length of states list needs to be RNN layers times 2 (h and c for each)"
+        self.lstm_states = states
 
     def model_name(self):
         """Returns the name of the present model for saving to disk"""
@@ -328,28 +300,26 @@ class PredictiveMusicMDRNN(object):
 
     def prepare_model_for_running(self):
         """Reset RNN state."""
-        self.model.reset_states()  # reset LSTM state.
+        self.reset_lstm_states()  # reset LSTM state.
 
     def generate_touch(self, prev_sample):
-        # TODO - do something with the session.
-        output = generate_sample(
-            self.model,
-            self.n_mixtures,
-            prev_sample,
-            pi_temp=self.pi_temp,
-            sigma_temp=self.sigma_temp,
-            out_dim=self.dimension,
-        )
-        return output
+        """Generate one forward prediction from a previous sample in format
+        (dt, x_1,...,x_n). Pi and Sigma temperature are adjustable."""
+        assert len(prev_sample) == self.dimension, "Only works with samples of the same dimension as the network"
+        # print("Input sample", prev_sample)
+        input_list = [prev_sample.reshape(1, 1, self.dimension) * SCALE_FACTOR] + self.lstm_states
+        model_output = self.model(input_list)
+        mdn_params = model_output[0][0].numpy()
+        self.lstm_states = model_output[1:] # update storage of LSTM state
 
-    def generate_performance(self, first_sample, number):
-        return generate_performance(
-            self.model,
-            self.n_mixtures,
-            first_sample,
-            time_limit=None,
-            steps_limit=number,
-            pi_temp=self.pi_temp,
-            sigma_temp=self.sigma_temp,
-            out_dim=self.dimension,
+        # sample from the MDN:
+        new_sample = (
+            mdn.sample_from_output(
+                mdn_params, self.dimension, self.n_mixtures, temp=self.pi_temp, sigma_temp=self.sigma_temp
+            )
+            / SCALE_FACTOR
         )
+        new_sample = new_sample.reshape(
+            self.dimension,
+        )
+        return new_sample

--- a/impsy/mdrnn/__init__.py
+++ b/impsy/mdrnn/__init__.py
@@ -154,10 +154,11 @@ def generate_sample(
 ):
     """Generate one forward prediction from a previous sample in format
     (dt, x_1,...,x_n). Pi and Sigma temperature are adjustable."""
-    params = model.predict(prev_sample.reshape(1, 1, out_dim) * SCALE_FACTOR)
+    model_output = model(prev_sample.reshape(1, 1, out_dim) * SCALE_FACTOR)
+    mdn_params = model_output[0].numpy()
     new_sample = (
         mdn.sample_from_output(
-            params[0], out_dim, n_mixtures, temp=pi_temp, sigma_temp=sigma_temp
+            mdn_params, out_dim, n_mixtures, temp=pi_temp, sigma_temp=sigma_temp
         )
         / SCALE_FACTOR
     )

--- a/impsy/mdrnn/test_model.py
+++ b/impsy/mdrnn/test_model.py
@@ -14,7 +14,7 @@ def test_model():
 def test_inference():
     """Test inference from a PredictiveMusicMDRNN model"""
     dimension = 8
-    num_test_steps = 5
+    num_test_steps = 20
     net = PredictiveMusicMDRNN(mode=NET_MODE_RUN, dimension=dimension)
     value = random_sample(out_dim=dimension)
     for i in range(num_test_steps):
@@ -24,7 +24,7 @@ def test_inference():
 
 def test_training():
     """Test training on a PredictiveMusicMDRNN model"""
-    num_epochs = 1
+    num_epochs = 2
     sequence_length = 100
     net = PredictiveMusicMDRNN(
         mode=NET_MODE_TRAIN,

--- a/impsy/mdrnn/test_model.py
+++ b/impsy/mdrnn/test_model.py
@@ -1,7 +1,7 @@
 from . import PredictiveMusicMDRNN, NET_MODE_RUN, NET_MODE_TRAIN
 from . import slice_sequence_examples, seq_to_overlapping_format, random_sample
 from . import sample_data
-import tensorflow.compat.v1 as tf
+import tensorflow as tf
 import numpy as np
 
 

--- a/impsy/tests.py
+++ b/impsy/tests.py
@@ -9,6 +9,7 @@ pd.set_option("display.float_format", lambda x: "%.2f" % x)
 def build_network(dimension=4, units=64, mixes=5, layers=2):
     """Build an MDRNN model."""
     import impsy.mdrnn as mdrnn
+
     mdrnn.MODEL_DIR = "./models/"
     net = mdrnn.PredictiveMusicMDRNN(
         mode=mdrnn.NET_MODE_RUN,
@@ -41,7 +42,12 @@ def prediction_speed_test():
     """This command runs a speed test experiment with different sized MDRNN models. The output is written to a CSV file."""
     start_import = time.time()
     import impsy.mdrnn as mdrnn
-    print("Importing MDRNN packages took", round(time.time() - start_import, 2), "seconds.")
+
+    print(
+        "Importing MDRNN packages took",
+        round(time.time() - start_import, 2),
+        "seconds.",
+    )
 
     def request_rnn_prediction(input_value, net):
         """Accesses a single prediction from the RNN."""

--- a/impsy/tests.py
+++ b/impsy/tests.py
@@ -24,8 +24,7 @@ def build_network(dimension=4, units=64, mixes=5, layers=2):
 @click.command(name="test-mdrnn")
 def test_mdrnn():
     """This command simply loads the MDRNN to test that it works and how long it takes."""
-    # import tensorflow, do this now to make CLI more responsive.
-    print("Building MDRNN.")
+    click.secho("Building MDRNN.")
     start_build = time.time()
     model_config = mdrnn_config("s")
     build_network(
@@ -34,20 +33,13 @@ def test_mdrnn():
         model_config["mixes"],
         model_config["layers"],
     )
-    print("Done. That took", round(time.time() - start_build, 2), "seconds.")
+    click.secho(f"Done in {round(time.time() - start_build, 2)}s.")
 
 
 @click.command(name="test-speed")
 def prediction_speed_test():
     """This command runs a speed test experiment with different sized MDRNN models. The output is written to a CSV file."""
-    start_import = time.time()
     import impsy.mdrnn as mdrnn
-
-    print(
-        "Importing MDRNN packages took",
-        round(time.time() - start_import, 2),
-        "seconds.",
-    )
 
     def request_rnn_prediction(input_value, net):
         """Accesses a single prediction from the RNN."""
@@ -88,4 +80,4 @@ def prediction_speed_test():
             experiments.extend(times)
     total_experiment = pd.DataFrame.from_records(experiments)
     total_experiment.to_csv("total_exp.csv")
-    print(total_experiment.describe())
+    click.secho(total_experiment.describe())

--- a/impsy/tests.py
+++ b/impsy/tests.py
@@ -6,21 +6,17 @@ import pandas as pd
 pd.set_option("display.float_format", lambda x: "%.2f" % x)
 
 
-def build_network(sess, compute_graph, dimension=4, units=64, mixes=5, layers=2):
+def build_network(dimension=4, units=64, mixes=5, layers=2):
     """Build an MDRNN model."""
     import impsy.mdrnn as mdrnn
-    import tensorflow.compat.v1 as tf
-
     mdrnn.MODEL_DIR = "./models/"
-    tf.keras.backend.set_session(sess)
-    with compute_graph.as_default():
-        net = mdrnn.PredictiveMusicMDRNN(
-            mode=mdrnn.NET_MODE_RUN,
-            dimension=dimension,
-            n_hidden_units=units,
-            n_mixtures=mixes,
-            layers=layers,
-        )
+    net = mdrnn.PredictiveMusicMDRNN(
+        mode=mdrnn.NET_MODE_RUN,
+        dimension=dimension,
+        n_hidden_units=units,
+        n_mixtures=mixes,
+        layers=layers,
+    )
     return net
 
 
@@ -28,27 +24,16 @@ def build_network(sess, compute_graph, dimension=4, units=64, mixes=5, layers=2)
 def test_mdrnn():
     """This command simply loads the MDRNN to test that it works and how long it takes."""
     # import tensorflow, do this now to make CLI more responsive.
-    print("Importing MDRNN.")
-    start_import = time.time()
-    import impsy.mdrnn as mdrnn
-    import tensorflow.compat.v1 as tf
-
-    print("Importing MDRNN packages took", time.time() - start_import, "seconds.")
-
+    print("Building MDRNN.")
     start_build = time.time()
-    compute_graph = tf.Graph()
-    with compute_graph.as_default():
-        sess = tf.Session()
     model_config = mdrnn_config("s")
     build_network(
-        sess,
-        compute_graph,
         4,
         model_config["units"],
         model_config["mixes"],
         model_config["layers"],
     )
-    print("Done. That took", time.time() - start_build, "seconds.")
+    print("Done. That took", round(time.time() - start_build, 2), "seconds.")
 
 
 @click.command(name="test-speed")
@@ -56,9 +41,7 @@ def prediction_speed_test():
     """This command runs a speed test experiment with different sized MDRNN models. The output is written to a CSV file."""
     start_import = time.time()
     import impsy.mdrnn as mdrnn
-    import tensorflow.compat.v1 as tf
-
-    print("Importing MDRNN packages took", time.time() - start_import, "seconds.")
+    print("Importing MDRNN packages took", round(time.time() - start_import, 2), "seconds.")
 
     def request_rnn_prediction(input_value, net):
         """Accesses a single prediction from the RNN."""
@@ -69,12 +52,7 @@ def prediction_speed_test():
 
     def run_test(tests, config):
         times = []
-        compute_graph = tf.Graph()
-        with compute_graph.as_default():
-            sess = tf.Session()
         net = build_network(
-            sess,
-            compute_graph,
             config["dimension"],
             config["units"],
             config["mixes"],
@@ -83,9 +61,7 @@ def prediction_speed_test():
         for i in range(tests):
             ## Predictions.
             item = mdrnn.random_sample(out_dim=config["dimension"])
-            tf.keras.backend.set_session(sess)
-            with compute_graph.as_default():
-                rnn_output, t = request_rnn_prediction(item, net)
+            rnn_output, t = request_rnn_prediction(item, net)
             out_dict = {
                 "time": t,
                 "mixes": config["mixes"],
@@ -94,9 +70,6 @@ def prediction_speed_test():
                 "dimension": config["dimension"],
             }
             times.append(out_dict)
-        # clean up
-        tf.keras.backend.clear_session()
-        sess.close()
         return times
 
     experiments = []

--- a/impsy/train.py
+++ b/impsy/train.py
@@ -2,23 +2,16 @@
 
 import random
 import numpy as np
-import os
 import datetime
 import click
 from .utils import mdrnn_config
 
 
-# Input and output to serial are bytes (0-255)
-# Output to Pd is a float (0-1)
-
-
-# Model Hyperparameters
+# Model training hyperparameters
 SEQ_LEN = 50
 SEQ_STEP = 1
 TIME_DIST = True
-# Training Hyperparameters:
 VAL_SPLIT = 0.10
-# Set random seed for reproducibility
 SEED = 2345
 
 
@@ -74,21 +67,8 @@ def train(
     batchsize: int,
 ):
     """Trains a predictive music interaction model."""
-
-    # Hack to get openMP working annoyingly.
-    os.environ["KMP_DUPLICATE_LIB_OK"] = "True"  # TODO: is this necessary?
-    # Import IMPS MDRNN at this point so CLI is fast.
     import impsy.mdrnn as mdrnn
-    from tensorflow.compat.v1 import keras
-    import tensorflow.compat.v1 as tf
-
-    # Set up environment.
-    # Only for GPU use:
-    os.environ["CUDA_VISIBLE_DEVICES"] = "0"
-    config = tf.ConfigProto()
-    config.gpu_options.allow_growth = True
-    sess = tf.Session(config=config)
-    tf.keras.backend.set_session(sess)
+    from tensorflow import keras
 
     model_config = mdrnn_config(modelsize)
     mdrnn_units = model_config["units"]
@@ -106,13 +86,11 @@ def train(
     # Load dataset
     dataset_location = f"{source}/"
     dataset_filename = f"training-dataset-{str(dimension)}d.npz"
-
     with np.load(dataset_location + dataset_filename, allow_pickle=True) as loaded:
-        perfs = loaded["perfs"]
+        corpus = loaded["perfs"]
 
-    print("Loaded perfs:", len(perfs))
-    print("Num touches:", np.sum([len(l) for l in perfs]))
-    corpus = perfs  # might need to do some processing here...processing
+    print("Loaded perfs:", len(corpus))
+    print("Num touches:", np.sum([len(l) for l in corpus]))
     # Restrict corpus to sequences longer than the corpus.
     corpus = [l for l in corpus if len(l) > SEQ_LEN + 1]
     print("Corpus Examples:", len(corpus))

--- a/impsy/train.py
+++ b/impsy/train.py
@@ -89,9 +89,9 @@ def train(
     with np.load(dataset_location + dataset_filename, allow_pickle=True) as loaded:
         corpus = loaded["perfs"]
 
-    print("Loaded perfs:", len(corpus))
+    print("Loaded performances:", len(corpus))
     print("Num touches:", np.sum([len(l) for l in corpus]))
-    # Restrict corpus to sequences longer than the corpus.
+    # Restrict corpus to performances longer than the training sequence length.
     corpus = [l for l in corpus if len(l) > SEQ_LEN + 1]
     print("Corpus Examples:", len(corpus))
     # Prepare training data as X and Y.
@@ -134,7 +134,8 @@ def train(
     )
     date_string = datetime.datetime.today().strftime("%Y%m%d-%H_%M_%S")
 
-    filepath = model_dir + model_name + "-E{epoch:02d}-VL{val_loss:.2f}.hdf5"
+    # filepath = model_dir + model_name + "-E{epoch:02d}-VL{val_loss:.2f}.keras"
+    filepath = model_dir + model_name + "-ckpt.keras"
     checkpoint = keras.callbacks.ModelCheckpoint(
         filepath, monitor="val_loss", verbose=1, save_best_only=True, mode="min"
     )

--- a/impsy/train.py
+++ b/impsy/train.py
@@ -137,7 +137,6 @@ def train(
         out_dim=dimension,
         time_dist=TIME_DIST,
         inference=False,
-        compile_model=True,
         print_summary=True,
     )
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -262,6 +262,13 @@ files = [
     {file = "dm_tree-0.1.8-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fa42a605d099ee7d41ba2b5fb75e21423951fd26e5d50583a00471238fb3021d"},
     {file = "dm_tree-0.1.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b7764de0d855338abefc6e3ee9fe40d301668310aa3baea3f778ff051f4393"},
     {file = "dm_tree-0.1.8-cp311-cp311-win_amd64.whl", hash = "sha256:a5d819c38c03f0bb5b3b3703c60e4b170355a0fc6b5819325bf3d4ceb3ae7e80"},
+    {file = "dm_tree-0.1.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ea9e59e0451e7d29aece402d9f908f2e2a80922bcde2ebfd5dcb07750fcbfee8"},
+    {file = "dm_tree-0.1.8-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:94d3f0826311f45ee19b75f5b48c99466e4218a0489e81c0f0167bda50cacf22"},
+    {file = "dm_tree-0.1.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:435227cf3c5dc63f4de054cf3d00183790bd9ead4c3623138c74dde7f67f521b"},
+    {file = "dm_tree-0.1.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09964470f76a5201aff2e8f9b26842976de7889300676f927930f6285e256760"},
+    {file = "dm_tree-0.1.8-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:75c5d528bb992981c20793b6b453e91560784215dffb8a5440ba999753c14ceb"},
+    {file = "dm_tree-0.1.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0a94aba18a35457a1b5cd716fd7b46c5dafdc4cf7869b4bae665b91c4682a8e"},
+    {file = "dm_tree-0.1.8-cp312-cp312-win_amd64.whl", hash = "sha256:96a548a406a6fb15fe58f6a30a57ff2f2aafbf25f05afab00c8f5e5977b6c715"},
     {file = "dm_tree-0.1.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8c60a7eadab64c2278861f56bca320b2720f163dca9d7558103c3b77f2416571"},
     {file = "dm_tree-0.1.8-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:af4b3d372f2477dcd89a6e717e4a575ca35ccc20cc4454a8a4b6f8838a00672d"},
     {file = "dm_tree-0.1.8-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:de287fabc464b8734be251e46e06aa9aa1001f34198da2b6ce07bd197172b9cb"},
@@ -513,24 +520,17 @@ name = "keras-mdn-layer"
 version = "0.4.2"
 description = "An MDN Layer for Keras using TensorFlow's distributions module"
 optional = false
-python-versions = ">=3.11,<3.12"
-files = []
-develop = false
+python-versions = "<3.12,>=3.11"
+files = [
+    {file = "keras_mdn_layer-0.4.2-py3-none-any.whl", hash = "sha256:a6f5f8d71f82be544513132bdba9450f23ba338ea23e206a832502a1d0830d4e"},
+    {file = "keras_mdn_layer-0.4.2.tar.gz", hash = "sha256:7f3af8eef30fbca299ea1ac9de0ae454edc219f19a181cbb757d5b695a83e23b"},
+]
 
 [package.dependencies]
-numpy = "^1.26.4"
-tensorflow = [
-    {version = ">=2.15.0,<2.16.0", markers = "platform_machine == \"x86_64\" and (sys_platform == \"darwin\" or sys_platform == \"win32\" or sys_platform == \"linux\") or sys_platform == \"win32\""},
-    {url = "https://github.com/PINTO0309/Tensorflow-bin/releases/download/v2.15.0.post1/tensorflow-2.15.0.post1-cp311-none-linux_aarch64.whl", markers = "sys_platform == \"linux\" and platform_machine == \"aarch64\""},
-]
-tensorflow-macos = {version = "~2.15.0", markers = "sys_platform == \"darwin\" and platform_machine == \"aarch64\""}
+numpy = ">=1.26.4,<2.0.0"
+tensorflow = {version = ">=2.15.0,<2.16.0", markers = "sys_platform == \"darwin\" and platform_machine == \"x86_64\" or sys_platform == \"linux\" or sys_platform == \"win32\""}
+tensorflow-macos = {version = "2.15.0", markers = "sys_platform == \"darwin\" and platform_machine == \"arm64\""}
 tensorflow-probability = "0.23.0"
-
-[package.source]
-type = "git"
-url = "https://github.com/cpmpercussion/keras-mdn-layer.git"
-reference = "master"
-resolved_reference = "8058862df2c518842e9ad81a7598269724b8bf26"
 
 [[package]]
 name = "libclang"
@@ -700,38 +700,6 @@ files = [
 
 [package.dependencies]
 numpy = {version = ">=1.23.3", markers = "python_version > \"3.10\""}
-
-[package.extras]
-dev = ["absl-py", "pyink", "pylint (>=2.6.0)", "pytest", "pytest-xdist"]
-
-[[package]]
-name = "ml-dtypes"
-version = "0.3.2"
-description = ""
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "ml_dtypes-0.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7afde548890a92b41c0fed3a6c525f1200a5727205f73dc21181a2726571bb53"},
-    {file = "ml_dtypes-0.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1a746fe5fb9cd974a91070174258f0be129c592b93f9ce7df6cc336416c3fbd"},
-    {file = "ml_dtypes-0.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:961134ea44c7b8ca63eda902a44b58cd8bd670e21d62e255c81fba0a8e70d9b7"},
-    {file = "ml_dtypes-0.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:6b35c4e8ca957c877ac35c79ffa77724ecc3702a1e4b18b08306c03feae597bb"},
-    {file = "ml_dtypes-0.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:763697ab8a88d47443997a7cdf3aac7340049aed45f7521f6b0ec8a0594821fe"},
-    {file = "ml_dtypes-0.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b89b194e9501a92d289c1ffd411380baf5daafb9818109a4f49b0a1b6dce4462"},
-    {file = "ml_dtypes-0.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c34f2ba9660b21fe1034b608308a01be82bbef2a92fb8199f24dc6bad0d5226"},
-    {file = "ml_dtypes-0.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:6604877d567a29bfe7cc02969ae0f2425260e5335505cf5e7fefc3e5465f5655"},
-    {file = "ml_dtypes-0.3.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:93b78f53431c93953f7850bb1b925a17f0ab5d97527e38a7e865b5b4bc5cfc18"},
-    {file = "ml_dtypes-0.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a17ef2322e60858d93584e9c52a5be7dd6236b056b7fa1ec57f1bb6ba043e33"},
-    {file = "ml_dtypes-0.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8505946df1665db01332d885c2020b4cb9e84a8b1241eb4ba69d59591f65855"},
-    {file = "ml_dtypes-0.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:f47619d978ab1ae7dfdc4052ea97c636c6263e1f19bd1be0e42c346b98d15ff4"},
-    {file = "ml_dtypes-0.3.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c7b3fb3d4f6b39bcd4f6c4b98f406291f0d681a895490ee29a0f95bab850d53c"},
-    {file = "ml_dtypes-0.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a4c3fcbf86fa52d0204f07cfd23947ef05b4ad743a1a988e163caa34a201e5e"},
-    {file = "ml_dtypes-0.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91f8783fd1f2c23fd3b9ee5ad66b785dafa58ba3cdb050c4458021fa4d1eb226"},
-    {file = "ml_dtypes-0.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:7ba8e1fafc7fff3e643f453bffa7d082df1678a73286ce8187d3e825e776eb94"},
-    {file = "ml_dtypes-0.3.2.tar.gz", hash = "sha256:533059bc5f1764fac071ef54598db358c167c51a718f68f5bb55e3dee79d2967"},
-]
-
-[package.dependencies]
-numpy = {version = ">=1.23.3", markers = "python_version >= \"3.11\""}
 
 [package.extras]
 dev = ["absl-py", "pyink", "pylint (>=2.6.0)", "pytest", "pytest-xdist"]
@@ -1328,98 +1296,6 @@ type = "url"
 url = "https://github.com/PINTO0309/Tensorflow-bin/releases/download/v2.15.0.post1/tensorflow-2.15.0.post1-cp311-none-linux_aarch64.whl"
 
 [[package]]
-name = "tensorflow"
-version = "2.15.1"
-description = "TensorFlow is an open source machine learning framework for everyone."
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "tensorflow-2.15.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:91b51a507007d63a70b65be307d701088d15042a6399c0e2312b53072226e909"},
-    {file = "tensorflow-2.15.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:10132acc072d59696c71ce7221d2d8e0e3ff1e6bc8688dbac6d7aed8e675b710"},
-    {file = "tensorflow-2.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30c5ef9c758ec9ff7ce2aff76b71c980bc5119b879071c2cc623b1591a497a1a"},
-    {file = "tensorflow-2.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea290e435464cf0794f657b48786e5fa413362abe55ed771c172c25980d070ce"},
-    {file = "tensorflow-2.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:8e5431d45ceb416c2b1b6de87378054fbac7d2ed35d45b102d89a786613fffdc"},
-    {file = "tensorflow-2.15.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:6761efe511e6ee0f893f60738fefbcc51d6dc386eeaaafea59d21899ef369ffd"},
-    {file = "tensorflow-2.15.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:aa926114d1e13ffe5b2ea59c3f195216f26646d7fe36e9e5207b291e4b7902ff"},
-    {file = "tensorflow-2.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e73d43dbc68d8c711e70edecc4ac70472799a25ec4ec18a84d479ee18033d3c5"},
-    {file = "tensorflow-2.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb0edd69103c154245c5f209f0507355cc68ba7e4de350084bc31edc562478e4"},
-    {file = "tensorflow-2.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:a49f8755c74a89553294a99ab25aa87ab1cddbfa40fe58387e09f64f0578cedc"},
-    {file = "tensorflow-2.15.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:f8e85821317c9c0fbf1256e9f721cfb1400ba1e09becb844b3ddd91f744805fc"},
-    {file = "tensorflow-2.15.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:b75815b6a601edad52b4181e9805c8fcd04813a6ab1d5cd8127188dfd2788e20"},
-    {file = "tensorflow-2.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432788ac5d1234b9e9b7c7f73603a5655271a28c293329c52c7c0b9434a1184e"},
-    {file = "tensorflow-2.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89b5aa1022dec47e567512eaf4e1271b8e6c1ff1984e30d0d9127bd1093ed4c5"},
-    {file = "tensorflow-2.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:aaf3cfa290597ebbdf19d1a78729e3f555e459506cd58f8d7399359ac5e02a05"},
-]
-
-[package.dependencies]
-absl-py = ">=1.0.0"
-astunparse = ">=1.6.0"
-flatbuffers = ">=23.5.26"
-gast = ">=0.2.1,<0.5.0 || >0.5.0,<0.5.1 || >0.5.1,<0.5.2 || >0.5.2"
-google-pasta = ">=0.1.1"
-grpcio = ">=1.24.3,<2.0"
-h5py = ">=2.9.0"
-keras = ">=2.15.0,<2.16"
-libclang = ">=13.0.0"
-ml-dtypes = ">=0.3.1,<0.4.0"
-numpy = ">=1.23.5,<2.0.0"
-opt-einsum = ">=2.3.2"
-packaging = "*"
-protobuf = ">=3.20.3,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
-setuptools = "*"
-six = ">=1.12.0"
-tensorboard = ">=2.15,<2.16"
-tensorflow-cpu-aws = {version = "2.15.1", markers = "platform_system == \"Linux\" and (platform_machine == \"arm64\" or platform_machine == \"aarch64\")"}
-tensorflow-estimator = ">=2.15.0,<2.16"
-tensorflow-intel = {version = "2.15.1", markers = "platform_system == \"Windows\""}
-tensorflow-io-gcs-filesystem = ">=0.23.1"
-termcolor = ">=1.1.0"
-typing-extensions = ">=3.6.6"
-wrapt = ">=1.11.0,<1.15"
-
-[package.extras]
-and-cuda = ["nvidia-cublas-cu12 (==12.2.5.6)", "nvidia-cuda-cupti-cu12 (==12.2.142)", "nvidia-cuda-nvcc-cu12 (==12.2.140)", "nvidia-cuda-nvrtc-cu12 (==12.2.140)", "nvidia-cuda-runtime-cu12 (==12.2.140)", "nvidia-cudnn-cu12 (==8.9.4.25)", "nvidia-cufft-cu12 (==11.0.8.103)", "nvidia-curand-cu12 (==10.3.3.141)", "nvidia-cusolver-cu12 (==11.5.2.141)", "nvidia-cusparse-cu12 (==12.1.2.141)", "nvidia-nccl-cu12 (==2.16.5)", "nvidia-nvjitlink-cu12 (==12.2.140)"]
-
-[[package]]
-name = "tensorflow-cpu-aws"
-version = "2.15.1"
-description = "TensorFlow is an open source machine learning framework for everyone."
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "tensorflow_cpu_aws-2.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c781d95cb8c58d47cb012b7b4e77b2f3e8d4d47b45926bc54976506fa0c037cc"},
-    {file = "tensorflow_cpu_aws-2.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4c3a3a9363bf42999adedbbd514e3a133be2d62f61fee9cfa46aaefb087c09e"},
-    {file = "tensorflow_cpu_aws-2.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9a25f2b9da4740074fdd89bd2a4cf280a9d40b1d26a973ef079e6673c1bf7de"},
-]
-
-[package.dependencies]
-absl-py = ">=1.0.0"
-astunparse = ">=1.6.0"
-flatbuffers = ">=23.5.26"
-gast = ">=0.2.1,<0.5.0 || >0.5.0,<0.5.1 || >0.5.1,<0.5.2 || >0.5.2"
-google-pasta = ">=0.1.1"
-grpcio = ">=1.24.3,<2.0"
-h5py = ">=2.9.0"
-keras = ">=2.15.0,<2.16"
-libclang = ">=13.0.0"
-ml-dtypes = ">=0.3.1,<0.4.0"
-numpy = ">=1.23.5,<2.0.0"
-opt-einsum = ">=2.3.2"
-packaging = "*"
-protobuf = ">=3.20.3,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
-setuptools = "*"
-six = ">=1.12.0"
-tensorboard = ">=2.15,<2.16"
-tensorflow-estimator = ">=2.15.0,<2.16"
-tensorflow-io-gcs-filesystem = ">=0.23.1"
-termcolor = ">=1.1.0"
-typing-extensions = ">=3.6.6"
-wrapt = ">=1.11.0,<1.15"
-
-[package.extras]
-and-cuda = ["nvidia-cublas-cu12 (==12.2.5.6)", "nvidia-cuda-cupti-cu12 (==12.2.142)", "nvidia-cuda-nvcc-cu12 (==12.2.140)", "nvidia-cuda-nvrtc-cu12 (==12.2.140)", "nvidia-cuda-runtime-cu12 (==12.2.140)", "nvidia-cudnn-cu12 (==8.9.4.25)", "nvidia-cufft-cu12 (==11.0.8.103)", "nvidia-curand-cu12 (==10.3.3.141)", "nvidia-cusolver-cu12 (==11.5.2.141)", "nvidia-cusparse-cu12 (==12.1.2.141)", "nvidia-nccl-cu12 (==2.16.5)", "nvidia-nvjitlink-cu12 (==12.2.140)"]
-
-[[package]]
 name = "tensorflow-estimator"
 version = "2.15.0"
 description = "TensorFlow Estimator."
@@ -1428,45 +1304,6 @@ python-versions = ">=3.7"
 files = [
     {file = "tensorflow_estimator-2.15.0-py2.py3-none-any.whl", hash = "sha256:aedf21eec7fb2dc91150fc91a1ce12bc44dbb72278a08b58e79ff87c9e28f153"},
 ]
-
-[[package]]
-name = "tensorflow-intel"
-version = "2.15.1"
-description = "TensorFlow is an open source machine learning framework for everyone."
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "tensorflow_intel-2.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:9f305142b3c5e239c82c463429b1f88726dd27d9f23523871f825493a9ffc5f4"},
-    {file = "tensorflow_intel-2.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:4f05059493f8203285ac5cea3b1955887a7903c1ca6f7a29e4b6ef912b1f934b"},
-    {file = "tensorflow_intel-2.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:921f18f7eb9cf59769e9668b3935fe178c990e2973d8013870dae5e3b58de079"},
-]
-
-[package.dependencies]
-absl-py = ">=1.0.0"
-astunparse = ">=1.6.0"
-flatbuffers = ">=23.5.26"
-gast = ">=0.2.1,<0.5.0 || >0.5.0,<0.5.1 || >0.5.1,<0.5.2 || >0.5.2"
-google-pasta = ">=0.1.1"
-grpcio = ">=1.24.3,<2.0"
-h5py = ">=2.9.0"
-keras = ">=2.15.0,<2.16"
-libclang = ">=13.0.0"
-ml-dtypes = ">=0.3.1,<0.4.0"
-numpy = ">=1.23.5,<2.0.0"
-opt-einsum = ">=2.3.2"
-packaging = "*"
-protobuf = ">=3.20.3,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
-setuptools = "*"
-six = ">=1.12.0"
-tensorboard = ">=2.15,<2.16"
-tensorflow-estimator = ">=2.15.0,<2.16"
-tensorflow-io-gcs-filesystem = ">=0.23.1"
-termcolor = ">=1.1.0"
-typing-extensions = ">=3.6.6"
-wrapt = ">=1.11.0,<1.15"
-
-[package.extras]
-and-cuda = ["nvidia-cublas-cu12 (==12.2.5.6)", "nvidia-cuda-cupti-cu12 (==12.2.142)", "nvidia-cuda-nvcc-cu12 (==12.2.140)", "nvidia-cuda-nvrtc-cu12 (==12.2.140)", "nvidia-cuda-runtime-cu12 (==12.2.140)", "nvidia-cudnn-cu12 (==8.9.4.25)", "nvidia-cufft-cu12 (==11.0.8.103)", "nvidia-curand-cu12 (==10.3.3.141)", "nvidia-cusolver-cu12 (==11.5.2.141)", "nvidia-cusparse-cu12 (==12.1.2.141)", "nvidia-nccl-cu12 (==2.16.5)", "nvidia-nvjitlink-cu12 (==12.2.140)"]
 
 [[package]]
 name = "tensorflow-io-gcs-filesystem"
@@ -1538,25 +1375,6 @@ wrapt = ">=1.11.0,<1.15"
 
 [package.extras]
 and-cuda = ["nvidia-cublas-cu12 (==12.2.5.6)", "nvidia-cuda-cupti-cu12 (==12.2.142)", "nvidia-cuda-nvcc-cu12 (==12.2.140)", "nvidia-cuda-nvrtc-cu12 (==12.2.140)", "nvidia-cuda-runtime-cu12 (==12.2.140)", "nvidia-cudnn-cu12 (==8.9.4.25)", "nvidia-cufft-cu12 (==11.0.8.103)", "nvidia-curand-cu12 (==10.3.3.141)", "nvidia-cusolver-cu12 (==11.5.2.141)", "nvidia-cusparse-cu12 (==12.1.2.141)", "nvidia-nccl-cu12 (==2.16.5)", "nvidia-nvjitlink-cu12 (==12.2.140)", "tensorrt (==8.6.1.post1)", "tensorrt-bindings (==8.6.1)", "tensorrt-libs (==8.6.1)"]
-
-[[package]]
-name = "tensorflow-macos"
-version = "2.15.1"
-description = "TensorFlow is an open source machine learning framework for everyone."
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "tensorflow_macos-2.15.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:b8f01d7615fe4ff3b15a12f84471bd5344fed187543c4a091da3ddca51b6dc26"},
-    {file = "tensorflow_macos-2.15.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:58fca6399665f19e599c591c421672d9bc8b705409d43ececd0931d1d3bc6a7e"},
-    {file = "tensorflow_macos-2.15.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:cca3c9ba5b96face05716792cb1bcc70d84c5e0c34bfb7735b39c65d0334b699"},
-]
-
-[package.dependencies]
-tensorflow-cpu-aws = {version = "2.15.1", markers = "platform_system == \"Linux\" and (platform_machine == \"arm64\" or platform_machine == \"aarch64\")"}
-tensorflow-intel = {version = "2.15.1", markers = "platform_system == \"Windows\""}
-
-[package.extras]
-and-cuda = ["nvidia-cublas-cu12 (==12.2.5.6)", "nvidia-cuda-cupti-cu12 (==12.2.142)", "nvidia-cuda-nvcc-cu12 (==12.2.140)", "nvidia-cuda-nvrtc-cu12 (==12.2.140)", "nvidia-cuda-runtime-cu12 (==12.2.140)", "nvidia-cudnn-cu12 (==8.9.4.25)", "nvidia-cufft-cu12 (==11.0.8.103)", "nvidia-curand-cu12 (==10.3.3.141)", "nvidia-cusolver-cu12 (==11.5.2.141)", "nvidia-cusparse-cu12 (==12.1.2.141)", "nvidia-nccl-cu12 (==2.16.5)", "nvidia-nvjitlink-cu12 (==12.2.140)"]
 
 [[package]]
 name = "tensorflow-probability"
@@ -1832,4 +1650,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "a8e66f728871eb119621d91e352ce61d53347cb69154f7735c3b35366fe9ffcc"
+content-hash = "7f1dd189afadec958285e4fe33e1ea2bb406858e47824590ca3daa3b02c2b8da"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.12"
-tensorflow-macos = {markers="sys_platform == 'darwin' and platform_machine == 'aarch64'", version = "~2.15.0"}
+tensorflow-macos = {markers="sys_platform == 'darwin' and platform_machine == 'arm64'", version = "2.15.0"}
 tensorflow = [
   {markers="sys_platform == 'darwin' and platform_machine == 'x86_64'", version = "2.15.0"},
   {markers="sys_platform == 'linux' and platform_machine == 'x86_64'", version = "2.15.0"},
@@ -18,7 +18,7 @@ tensorflow = [
 tensorflow-probability = "0.23.0"
 h5py = "~3.10.0"
 python-osc = "^1.8.3"
-keras-mdn-layer = "~0.4.1"
+keras-mdn-layer = "~0.4.2"
 pyserial = "^3.5"
 websockets = "^12.0"
 mido = "^1.3.2"
@@ -27,7 +27,7 @@ click = "^8.1.7"
 pandas = "^2.2.2"
 
 [tool.poetry.group.dev.dependencies]
-keras-mdn-layer = { git = "https://github.com/cpmpercussion/keras-mdn-layer.git", branch = "master" }
+# keras-mdn-layer = { git = "https://github.com/cpmpercussion/keras-mdn-layer.git", branch = "master" }
 pytest = "^8.2.2"
 flake8 = "^7.0.0"
 black = "^24.4.2"


### PR DESCRIPTION
Updated mdrnn to tf2 api following same work in keras-mdn-layer.

With a new design that stores LSTM state in the model object, I could eliminate some complexity in the interaction loop with old tf1 session and compute graph stuff getting cut.